### PR TITLE
Feature/move column

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "@babel/core": "7.2.2",
     "@blueprintjs/core": "^3.15.1",
     "@svgr/webpack": "^4.2.0",
+    "@types/jest": "^24.0.13",
+    "@types/webpack-env": "^1.13.9",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "9.0.0",
     "babel-jest": "^24.7.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,12 @@ App.propTypes = {
   createTask: PropTypes.func.isRequired
 };
 
+/** @param {function} dispatch */
 const mapDispatch = dispatch => ({
+  /**
+   * @param {string} title
+   * @param {string} description
+   */
   createTask: (title, description) => dispatch(actions.tasks.createTask(title, description))
 });
 

--- a/src/components/task/Task.jsx
+++ b/src/components/task/Task.jsx
@@ -1,4 +1,3 @@
-// @ts-check
 import React from "react";
 import PropTypes from "prop-types";
 import { Card, Elevation, H5 } from "@blueprintjs/core";

--- a/src/redux/modules/tasks.js
+++ b/src/redux/modules/tasks.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { mockTasks, status } from "../../constants";
 
 const CREATE = "waffle/tasks/CREATE";

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -1,4 +1,10 @@
+/*
 declare module "*.scss" {
   const content: { [className: string]: string };
   export = content;
+}
+*/
+declare module "*.scss" {
+  const content: any;
+  export default content;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1259,6 +1259,18 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@^24.0.13":
+  version "24.0.13"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.13.tgz#10f50b64cb05fb02411fbba49e9042a3a11da3f9"
+  integrity sha512-3m6RPnO35r7Dg+uMLj1+xfZaOgIHHHut61djNjzwExXN4/Pm9has9C6I1KMYSfz7mahDhWUOVg4HW/nZdv5Pww==
+  dependencies:
+    "@types/jest-diff" "*"
+
 "@types/node@*":
   version "12.0.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.2.tgz#3452a24edf9fea138b48fad4a0a028a683da1e40"
@@ -1300,6 +1312,11 @@
     "@types/node" "*"
     "@types/unist" "*"
     "@types/vfile-message" "*"
+
+"@types/webpack-env@^1.13.9":
+  version "1.13.9"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.13.9.tgz#a67287861c928ebf4159a908d1fb1a2a34d4097a"
+  integrity sha512-p8zp5xqkly3g4cCmo2mKOHI9+Z/kObmDj0BmjbDDJQlgDTiEGTbm17MEwTAusV6XceCy+bNw9q/ZHXHyKo3zkg==
 
 "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
   version "12.0.12"


### PR DESCRIPTION
# TypeScript Check for All Files

This PR solves this issue: #31 

Now I don't have to put `// @ts-check` at the beginning of every file; all files are enabled.

I accidentally pushed to `feature/move-column` branch. 