### PR TITLE
Feature/andela drag

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "jest-watch-typeahead": "^0.2.1",
     "react-dev-utils": "^8.0.0",
     "react-test-renderer": "^16.8.6",
-    "typings-for-css-modules-loader": "^1.7.0"
+    "typings-for-css-modules-loader": "^1.7.0",
+    "use-trace-update": "^1.2.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { BrowserRouter as Router, Route } from "react-router-dom";
 import "normalize.css/normalize.css";
@@ -26,14 +27,7 @@ App.propTypes = {
   createTask: PropTypes.func.isRequired
 };
 
-/** @param {function} dispatch */
-const mapDispatch = dispatch => ({
-  /**
-   * @param {string} title
-   * @param {string} description
-   */
-  createTask: (title, description) => dispatch(actions.tasks.createTask(title, description))
-});
+const mapDispatch = dispatch => bindActionCreators(actions.tasks, dispatch);
 
 export default connect(
   null,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { bindActionCreators } from "redux";
-import { connect } from "react-redux";
 import { BrowserRouter as Router, Route } from "react-router-dom";
+import { connect } from "react-redux";
 import "normalize.css/normalize.css";
 import "@blueprintjs/icons/lib/css/blueprint-icons.css";
 import "@blueprintjs/core/lib/css/blueprint.css";

--- a/src/components/task/Task.jsx
+++ b/src/components/task/Task.jsx
@@ -14,7 +14,14 @@ const options = Object.entries(status).map(([key, { title }]) => ({
 const Task = ({ changeStatus, deleteTask, task }) => (
   <Card
     draggable
-    onDrag={event => console.log(event)}
+    onDrag={event => {
+      // Some elements have undesired default drag behaviour. Prevent that.
+      event.preventDefault();
+      changeStatus({
+        ...task,
+        status: "DRAGGED"
+      });
+    }}
     interactive
     elevation={Elevation.TWO}
     className={styles.container}

--- a/src/components/task/Task.jsx
+++ b/src/components/task/Task.jsx
@@ -11,16 +11,22 @@ const options = Object.entries(status).map(([key, { title }]) => ({
   value: title
 }));
 
-const Task = ({ changeStatus, deleteTask, task }) => (
+const Task = ({ updateTask, deleteTask, task }) => (
   <Card
     draggable
     onDrag={event => {
       // Some elements have undesired default drag behaviour. Prevent that.
       event.preventDefault();
-      changeStatus({
+      updateTask({
         ...task,
-        status: "DRAGGED"
+        dragging: true
       });
+    }}
+    onDragStart={event => {
+      event.stopPropagation();
+      event.dataTransfer.effectAllowed = "move";
+      // Some browsers such as Firefox requires dummy data to enable dragging
+      event.dataTransfer.setData("text/plain", "some_dummy_data");
     }}
     interactive
     elevation={Elevation.TWO}
@@ -33,7 +39,7 @@ const Task = ({ changeStatus, deleteTask, task }) => (
         initial={task.status}
         options={options}
         onSelect={newStatus =>
-          changeStatus({
+          updateTask({
             ...task,
             status: newStatus
           })
@@ -47,14 +53,14 @@ const Task = ({ changeStatus, deleteTask, task }) => (
 );
 
 Task.propTypes = {
-  changeStatus: PropTypes.func.isRequired,
   deleteTask: PropTypes.func.isRequired,
   task: PropTypes.shape({
     description: PropTypes.string.isRequired,
     id: PropTypes.number.isRequired,
     status: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired
-  }).isRequired
+  }).isRequired,
+  updateTask: PropTypes.func.isRequired
 };
 
 export default Task;

--- a/src/components/task/Task.jsx
+++ b/src/components/task/Task.jsx
@@ -1,15 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
+import debounce from "lodash/debounce";
 import { Button } from "evergreen-ui";
 import { Card, Elevation, H5 } from "@blueprintjs/core";
 import styles from "./Task.module.scss";
-import { SelectMenu } from "../select-menu";
-import { status } from "../../constants";
-
-const options = Object.entries(status).map(([key, { title }]) => ({
-  label: title,
-  value: title
-}));
 
 const enableDrag = event => {
   event.stopPropagation();
@@ -18,46 +12,43 @@ const enableDrag = event => {
   event.dataTransfer.setData("text/plain", "some_dummy_data");
 };
 
-const Task = ({ updateTask, deleteTask, task }) => (
-  <Card
-    draggable
-    onDrag={event => {
-      // Some elements have undesired default drag behaviour. Prevent that.
-      event.preventDefault();
-      updateTask({
-        ...task,
-        dragging: true
-      });
-    }}
-    onDragStart={enableDrag}
-    interactive
-    elevation={Elevation.TWO}
-    className={styles.container}
-  >
-    <H5 className={styles.title}>{task.title}</H5>
-    {task.description}
-    <div className={styles.buttons}>
-      <SelectMenu
-        initial={task.status}
-        options={options}
-        onSelect={newStatus =>
-          updateTask({
-            ...task,
-            status: newStatus
-          })
-        }
-      />
-      <Button className={styles.deleteButton} intent="danger" onClick={() => deleteTask(task.id)}>
-        Delete
-      </Button>
-    </div>
-  </Card>
-);
+const Task = ({ updateTask, deleteTask, task }) => {
+  // The 'drag' event is fired several times per second; don't want to call our redux functions at the same frequency.
+  const updateDebounced = debounce(() => updateTask({ ...task, dragging: true }), 500, {
+    leading: true,
+    trailing: false
+  });
+
+  return (
+    <Card
+      className={styles.container}
+      draggable
+      elevation={Elevation.TWO}
+      interactive
+      onDrag={event => {
+        // Some elements have undesired default drag behaviour. Prevent that.
+        event.preventDefault();
+        updateDebounced();
+      }}
+      onDragStart={enableDrag}
+    >
+      <H5 className={styles.title}>{task.title}</H5>
+      {task.description}
+      <div className={styles.buttons}>
+        <p>Status: {task.status}</p>
+        <Button className={styles.deleteButton} intent="danger" onClick={() => deleteTask(task.id)}>
+          Delete
+        </Button>
+      </div>
+    </Card>
+  );
+};
 
 Task.propTypes = {
   deleteTask: PropTypes.func.isRequired,
   task: PropTypes.shape({
     description: PropTypes.string.isRequired,
+    dragging: PropTypes.bool.isRequired,
     id: PropTypes.number.isRequired,
     status: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired
@@ -65,4 +56,17 @@ Task.propTypes = {
   updateTask: PropTypes.func.isRequired
 };
 
-export default Task;
+/** @typedef { import('../../redux/modules/tasks').Task } TaskProps */
+
+/**
+ * a Task can have many props, but we only care about these 4 (e.g., we don't care about 'dragging')
+ * This doesn't scale very well when we change the implementation of Task in the future, but for now the readability gain
+ * is worth it.
+ * @param {{ task: TaskProps}} prevProps
+ * @param {{ task: TaskProps}} nextProps
+ * @returns {boolean}
+ */
+const isSameId = (prevProps, nextProps) =>
+  ["description", "id", "status", "title"].every(property => prevProps.task[property] === nextProps.task[property]);
+
+export default React.memo(Task, isSameId);

--- a/src/components/task/Task.jsx
+++ b/src/components/task/Task.jsx
@@ -12,7 +12,13 @@ const options = Object.entries(status).map(([key, { title }]) => ({
 }));
 
 const Task = ({ changeStatus, deleteTask, task }) => (
-  <Card interactive elevation={Elevation.TWO} className={styles.container}>
+  <Card
+    draggable
+    onDrag={event => console.log(event)}
+    interactive
+    elevation={Elevation.TWO}
+    className={styles.container}
+  >
     <H5 className={styles.title}>{task.title}</H5>
     {task.description}
     <div className={styles.buttons}>

--- a/src/components/task/Task.jsx
+++ b/src/components/task/Task.jsx
@@ -12,7 +12,7 @@ const enableDrag = event => {
   event.dataTransfer.setData("text/plain", "some_dummy_data");
 };
 
-const Task = ({ updateTask, deleteTask, task }) => {
+const Task = ({ deleteTask, task, updateTask }) => {
   // The 'drag' event is fired several times per second; don't want to call our redux functions at the same frequency.
   const updateDebounced = debounce(() => updateTask({ ...task, dragging: true }), 500, {
     leading: true,
@@ -56,9 +56,9 @@ Task.propTypes = {
 /** @typedef { import('../../redux/modules/tasks').Task } TaskProps */
 
 /**
- * a Task can have many props, but we only care about these 4 (e.g., we don't care about 'dragging')
- * This doesn't scale very well when we change the implementation of Task in the future, but for now the readability gain
- * is worth it.
+ * A task object can have many properties, but we only care about these 4 (e.g., we don't care about 'dragging')
+ * This doesn't scale very well when we change the implementation of Task in the future,
+ * but for now the readability gain is worth it.
  * @param {{ task: TaskProps}} prevProps
  * @param {{ task: TaskProps}} nextProps
  * @returns {boolean}
@@ -66,4 +66,5 @@ Task.propTypes = {
 const isSameId = (prevProps, nextProps) =>
   ["description", "id", "status", "title"].every(property => prevProps.task[property] === nextProps.task[property]);
 
+// Without React.memo, this component will cause an update feedback loop with Redux, that causes rerender several times per second.
 export default React.memo(Task, isSameId);

--- a/src/components/task/Task.jsx
+++ b/src/components/task/Task.jsx
@@ -34,12 +34,9 @@ const Task = ({ updateTask, deleteTask, task }) => {
     >
       <H5 className={styles.title}>{task.title}</H5>
       {task.description}
-      <div className={styles.buttons}>
-        <p>Status: {task.status}</p>
-        <Button className={styles.deleteButton} intent="danger" onClick={() => deleteTask(task.id)}>
-          Delete
-        </Button>
-      </div>
+      <Button className={styles.deleteButton} intent="danger" onClick={() => deleteTask(task.id)}>
+        Delete
+      </Button>
     </Card>
   );
 };

--- a/src/components/task/Task.jsx
+++ b/src/components/task/Task.jsx
@@ -11,6 +11,13 @@ const options = Object.entries(status).map(([key, { title }]) => ({
   value: title
 }));
 
+const enableDrag = event => {
+  event.stopPropagation();
+  event.dataTransfer.effectAllowed = "move";
+  // Some browsers such as Firefox requires dummy data to enable dragging
+  event.dataTransfer.setData("text/plain", "some_dummy_data");
+};
+
 const Task = ({ updateTask, deleteTask, task }) => (
   <Card
     draggable
@@ -22,12 +29,7 @@ const Task = ({ updateTask, deleteTask, task }) => (
         dragging: true
       });
     }}
-    onDragStart={event => {
-      event.stopPropagation();
-      event.dataTransfer.effectAllowed = "move";
-      // Some browsers such as Firefox requires dummy data to enable dragging
-      event.dataTransfer.setData("text/plain", "some_dummy_data");
-    }}
+    onDragStart={enableDrag}
     interactive
     elevation={Elevation.TWO}
     className={styles.container}

--- a/src/components/task/Task.module.scss
+++ b/src/components/task/Task.module.scss
@@ -9,5 +9,6 @@
 }
 
 .deleteButton {
+  display: block;
   margin-top: 10px;
 }

--- a/src/components/task/Task.module.scss
+++ b/src/components/task/Task.module.scss
@@ -8,10 +8,6 @@
   text-decoration: none;
 }
 
-.buttons {
-  margin-top: 10px;
-}
-
 .deleteButton {
-  margin-left: 10px;
+  margin-top: 10px;
 }

--- a/src/components/task/Task.module.scss.d.ts
+++ b/src/components/task/Task.module.scss.d.ts
@@ -1,4 +1,3 @@
 export const container: string;
 export const title: string;
-export const buttons: string;
 export const deleteButton: string;

--- a/src/components/task/TaskLane.jsx
+++ b/src/components/task/TaskLane.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { Icon } from "@blueprintjs/core";
 import styles from "./TaskLane.module.scss";
@@ -9,7 +10,10 @@ const TaskLane = ({ acceptTask, children, color, icon, title, lighterColor }) =>
   <div
     className={styles.container}
     onDragOver={event => event.preventDefault()}
-    onDrop={acceptTask}
+    onDrop={event => {
+      event.preventDefault();
+      acceptTask(title);
+    }}
     style={{
       backgroundColor: color
     }}
@@ -45,9 +49,7 @@ TaskLane.defaultProps = {
   lighterColor: "#eeeeee"
 };
 
-const mapDispatch = (dispatch, ownProps) => ({
-  acceptTask: () => dispatch(actions.tasks.acceptTask(ownProps.title))
-});
+const mapDispatch = dispatch => bindActionCreators(actions.tasks, dispatch);
 
 export default connect(
   null,

--- a/src/components/task/TaskLane.jsx
+++ b/src/components/task/TaskLane.jsx
@@ -8,7 +8,10 @@ import styles from "./TaskLane.module.scss";
 import { actions } from "../../redux";
 
 const TaskLane = ({ acceptTask, children, color, icon, title, lighterColor }) => {
-  // By setting a .drag class which says pointer-events:none; we prevent dragEnter, dragLeave and dragOver to be repeatedly fired many times
+  /**
+   * By setting a `.drag` class which says `pointer-events:none;`
+   * we prevent `dragEnter`, `dragLeave` and `dragOver` to be repeatedly fired many times
+   */
   const [dragClass, setDragClass] = useState("");
 
   return (
@@ -22,16 +25,9 @@ const TaskLane = ({ acceptTask, children, color, icon, title, lighterColor }) =>
         acceptTask(title);
         setDragClass("");
       }}
-      style={{
-        backgroundColor: color
-      }}
+      style={{ backgroundColor: color }}
     >
-      <h2
-        className={styles.title}
-        style={{
-          backgroundColor: lighterColor
-        }}
-      >
+      <h2 className={styles.title} style={{ backgroundColor: lighterColor }}>
         <span className={styles.titleLeft}>
           <Icon icon={icon} iconSize={20} />
           &nbsp; &nbsp;

--- a/src/components/task/TaskLane.jsx
+++ b/src/components/task/TaskLane.jsx
@@ -1,44 +1,32 @@
-import React, { useState } from "react";
+import React from "react";
 import PropTypes from "prop-types";
-import classNames from "classnames";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { Icon } from "@blueprintjs/core";
 import styles from "./TaskLane.module.scss";
 import { actions } from "../../redux";
 
-const TaskLane = ({ acceptTask, children, color, icon, title, lighterColor }) => {
-  /**
-   * By setting a `.drag` class which says `pointer-events:none;`
-   * we prevent `dragEnter`, `dragLeave` and `dragOver` to be repeatedly fired many times
-   */
-  const [dragClass, setDragClass] = useState("");
-
-  return (
-    <div
-      className={classNames(styles.container, dragClass)}
-      onDragEnter={() => setDragClass(styles.drag)}
-      onDragLeave={() => setDragClass("")}
-      onDragOver={event => event.preventDefault()}
-      onDrop={event => {
-        event.preventDefault();
-        acceptTask(title);
-        setDragClass("");
-      }}
-      style={{ backgroundColor: color }}
-    >
-      <h2 className={styles.title} style={{ backgroundColor: lighterColor }}>
-        <span className={styles.titleLeft}>
-          <Icon icon={icon} iconSize={20} />
-          &nbsp; &nbsp;
-          {title}
-        </span>
-        <span>{children.length}</span>
-      </h2>
-      {children}
-    </div>
-  );
-};
+const TaskLane = ({ acceptTask, children, color, icon, lighterColor, title }) => (
+  <div
+    className={styles.container}
+    onDragOver={event => event.preventDefault()}
+    onDrop={event => {
+      event.preventDefault();
+      acceptTask(title);
+    }}
+    style={{ backgroundColor: color }}
+  >
+    <h2 className={styles.title} style={{ backgroundColor: lighterColor }}>
+      <span className={styles.titleLeft}>
+        <Icon icon={icon} iconSize={20} />
+        &nbsp; &nbsp;
+        {title}
+      </span>
+      <span>{children.length}</span>
+    </h2>
+    {children}
+  </div>
+);
 
 TaskLane.propTypes = {
   acceptTask: PropTypes.func.isRequired,

--- a/src/components/task/TaskLane.jsx
+++ b/src/components/task/TaskLane.jsx
@@ -1,11 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { connect } from "react-redux";
 import { Icon } from "@blueprintjs/core";
 import styles from "./TaskLane.module.scss";
+import { actions } from "../../redux";
 
-const TaskLane = ({ children, color, icon, title, lighterColor }) => (
+const TaskLane = ({ acceptTask, children, color, icon, title, lighterColor }) => (
   <div
     className={styles.container}
+    onDragOver={event => event.preventDefault()}
+    onDrop={acceptTask}
     style={{
       backgroundColor: color
     }}
@@ -28,6 +32,7 @@ const TaskLane = ({ children, color, icon, title, lighterColor }) => (
 );
 
 TaskLane.propTypes = {
+  acceptTask: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
   color: PropTypes.string,
   icon: PropTypes.string.isRequired,
@@ -40,4 +45,11 @@ TaskLane.defaultProps = {
   lighterColor: "#eeeeee"
 };
 
-export default TaskLane;
+const mapDispatch = (dispatch, ownProps) => ({
+  acceptTask: () => dispatch(actions.tasks.acceptTask(ownProps.title))
+});
+
+export default connect(
+  null,
+  mapDispatch
+)(TaskLane);

--- a/src/components/task/TaskLane.jsx
+++ b/src/components/task/TaskLane.jsx
@@ -1,39 +1,48 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
+import classNames from "classnames";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { Icon } from "@blueprintjs/core";
 import styles from "./TaskLane.module.scss";
 import { actions } from "../../redux";
 
-const TaskLane = ({ acceptTask, children, color, icon, title, lighterColor }) => (
-  <div
-    className={styles.container}
-    onDragOver={event => event.preventDefault()}
-    onDrop={event => {
-      event.preventDefault();
-      acceptTask(title);
-    }}
-    style={{
-      backgroundColor: color
-    }}
-  >
-    <h2
-      className={styles.title}
+const TaskLane = ({ acceptTask, children, color, icon, title, lighterColor }) => {
+  // By setting a .drag class which says pointer-events:none; we prevent dragEnter, dragLeave and dragOver to be repeatedly fired many times
+  const [dragClass, setDragClass] = useState("");
+
+  return (
+    <div
+      className={classNames(styles.container, dragClass)}
+      onDragEnter={() => setDragClass(styles.drag)}
+      onDragLeave={() => setDragClass("")}
+      onDragOver={event => event.preventDefault()}
+      onDrop={event => {
+        event.preventDefault();
+        acceptTask(title);
+        setDragClass("");
+      }}
       style={{
-        backgroundColor: lighterColor
+        backgroundColor: color
       }}
     >
-      <span className={styles.titleLeft}>
-        <Icon icon={icon} iconSize={20} />
-        &nbsp; &nbsp;
-        {title}
-      </span>
-      <span>{children.length}</span>
-    </h2>
-    {children}
-  </div>
-);
+      <h2
+        className={styles.title}
+        style={{
+          backgroundColor: lighterColor
+        }}
+      >
+        <span className={styles.titleLeft}>
+          <Icon icon={icon} iconSize={20} />
+          &nbsp; &nbsp;
+          {title}
+        </span>
+        <span>{children.length}</span>
+      </h2>
+      {children}
+    </div>
+  );
+};
 
 TaskLane.propTypes = {
   acceptTask: PropTypes.func.isRequired,

--- a/src/components/task/TaskLane.module.scss
+++ b/src/components/task/TaskLane.module.scss
@@ -9,6 +9,10 @@
   padding-top: 50px;
 }
 
+.drag * {
+  pointer-events: none;
+}
+
 .title {
   align-items: center;
   box-shadow: rgba(0, 0, 0, 0.05) 0px 2px 5px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px;

--- a/src/components/task/TaskLane.module.scss.d.ts
+++ b/src/components/task/TaskLane.module.scss.d.ts
@@ -1,3 +1,4 @@
 export const container: string;
+export const drag: string;
 export const title: string;
 export const titleLeft: string;

--- a/src/components/task/TaskLane.test.jsx
+++ b/src/components/task/TaskLane.test.jsx
@@ -10,7 +10,7 @@ describe("TaskLane", () => {
     taskLane = (
       <TaskLane icon="pulse" title="In Progress">
         <Task
-          changeStatus={emptyFiller}
+          updateTask={emptyFiller}
           deleteTask={emptyFiller}
           task={{
             id: 1,
@@ -20,7 +20,7 @@ describe("TaskLane", () => {
           }}
         />
         <Task
-          changeStatus={emptyFiller}
+          updateTask={emptyFiller}
           deleteTask={emptyFiller}
           task={{
             id: 2,

--- a/src/constants.js
+++ b/src/constants.js
@@ -27,37 +27,43 @@ export const status = {
 
 export const mockTasks = [
   {
-    id: 1,
-    title: "Review iPhone XS Max",
     description: "Review the newest flagship iPhone.",
-    status: status.TO_DO.title
+    dragging: false,
+    id: 1,
+    status: status.TO_DO.title,
+    title: "Review iPhone XS Max"
   },
   {
-    id: 2,
-    title: "Review iPhone XR",
     description: 'Review the newest "budget-friendly" iPhone.',
-    status: status.TO_DO.title
+    dragging: false,
+    id: 2,
+    status: status.TO_DO.title,
+    title: "Review iPhone XR"
   },
   {
-    id: 3,
-    title: "Review Samsung Galaxy S10 Plus",
     description: "Review the newest Samsung flagship",
-    status: status.IN_PROGRESS.title
+    dragging: false,
+    id: 3,
+    status: status.IN_PROGRESS.title,
+    title: "Review Samsung Galaxy S10 Plus"
   },
   {
-    id: 4,
-    title: "Review Google Pixel 3 XL",
     description: "Can the Google's flagship compete with Apple and Samsung?",
-    status: status.IN_PROGRESS.title
+    dragging: false,
+    id: 4,
+    status: status.IN_PROGRESS.title,
+    title: "Review Google Pixel 3 XL"
   },
   {
     id: 5,
+    dragging: false,
     title: "Review OnePlus 6T",
     description: 'How much are we giving up for a "flagship killer"?',
     status: status.COMPLETED.title
   },
   {
     id: 6,
+    dragging: false,
     title: "Review BlackBerry KEY2",
     description: "Are physical keyboards still relevant, and worth the tradeoffs?",
     status: status.COMPLETED.title

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -7,14 +7,14 @@ import { actions } from "../redux";
 import { status } from "../constants";
 import { Task, TaskLane } from "../components/task";
 
-const Tasks = ({ updateTask, deleteTask, tasks }) => (
+const Tasks = ({ deleteTask, tasks, updateTask }) => (
   <div className={styles.container}>
-    {Object.entries(status).map(([key, object], index) => (
+    {Object.entries(status).map(([key, object]) => (
       <TaskLane key={object.title} {...object}>
         {tasks
           .filter(task => task.status === object.title)
           .map(task => (
-            <Task updateTask={updateTask} deleteTask={deleteTask} key={task.title} task={task} />
+            <Task deleteTask={deleteTask} key={task.title} task={task} updateTask={updateTask} />
           ))}
       </TaskLane>
     ))}

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -1,19 +1,20 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import styles from "./Tasks.module.scss";
 import { actions } from "../redux";
 import { status } from "../constants";
 import { Task, TaskLane } from "../components/task";
 
-const Tasks = ({ changeStatus, deleteTask, tasks }) => (
+const Tasks = ({ updateTask, deleteTask, tasks }) => (
   <div className={styles.container}>
     {Object.entries(status).map(([key, object], index) => (
       <TaskLane key={object.title} {...object}>
         {tasks
           .filter(task => task.status === object.title)
           .map(task => (
-            <Task changeStatus={changeStatus} deleteTask={deleteTask} key={task.title} task={task} />
+            <Task updateTask={updateTask} deleteTask={deleteTask} key={task.title} task={task} />
           ))}
       </TaskLane>
     ))}
@@ -21,7 +22,6 @@ const Tasks = ({ changeStatus, deleteTask, tasks }) => (
 );
 
 Tasks.propTypes = {
-  changeStatus: PropTypes.func.isRequired,
   deleteTask: PropTypes.func.isRequired,
   tasks: PropTypes.arrayOf(
     PropTypes.shape({
@@ -30,7 +30,8 @@ Tasks.propTypes = {
       status: PropTypes.string.isRequired,
       title: PropTypes.string.isRequired
     })
-  )
+  ),
+  updateTask: PropTypes.func.isRequired
 };
 
 Tasks.defaultProps = {
@@ -41,10 +42,7 @@ const mapState = ({ tasks }) => ({
   tasks
 });
 
-const mapDispatch = dispatch => ({
-  changeStatus: modifiedTask => dispatch(actions.tasks.updateTask(modifiedTask)),
-  deleteTask: id => dispatch(actions.tasks.deleteTask(id))
-});
+const mapDispatch = dispatch => bindActionCreators(actions.tasks, dispatch);
 
 export default connect(
   mapState,

--- a/src/redux/modules/tasks.js
+++ b/src/redux/modules/tasks.js
@@ -7,6 +7,7 @@ const DELETE = "waffle/tasks/DELETE";
 
 /**
  * @typedef {Object} Task
+ * @property {boolean} dragging
  * @property {number} id
  * @property {string} description
  * @property {string} status
@@ -27,10 +28,11 @@ const DELETE = "waffle/tasks/DELETE";
  */
 const acceptTaskReducer = (state, action) =>
   state.map(task =>
-    task.status === "DRAGGED"
+    task.dragging
       ? {
           ...task,
-          status: action.payload.status
+          status: action.payload.status,
+          dragging: false
         }
       : task
   );
@@ -44,8 +46,9 @@ const acceptTaskReducer = (state, action) =>
 const createTaskReducer = (state, action) => [
   ...state,
   {
-    id: state.length + 1,
     ...action.payload,
+    dragging: false,
+    id: state.length + 1,
     status: status.TO_DO.title
   }
 ];

--- a/src/redux/modules/tasks.js
+++ b/src/redux/modules/tasks.js
@@ -1,5 +1,6 @@
 import { mockTasks, status } from "../../constants";
 
+const ACCEPT = "waffle/tasks/ACCEPT"; // Fired when a Task is dropped in a TaskLane.
 const CREATE = "waffle/tasks/CREATE";
 const UPDATE = "waffle/tasks/UPDATE";
 const DELETE = "waffle/tasks/DELETE";
@@ -15,8 +16,24 @@ const DELETE = "waffle/tasks/DELETE";
 /**
  * @typedef {Object} Action
  * @property {string} type - The type of an action, such as 'waffle/tasks/CREATE'
- * @property {Object} payload
+ * @property {Object=} payload
  */
+
+/**
+ * Find the task with "DRAGGED" status, and change it to the new status.
+ * @param {Task[]} state
+ * @param {Action} action
+ * @returns {Task[]}
+ */
+const acceptTaskReducer = (state, action) =>
+  state.map(task =>
+    task.status === "DRAGGED"
+      ? {
+          ...task,
+          status: action.payload.status
+        }
+      : task
+  );
 
 /**
  * Create a new task and put it at the end of the existing list of tasks.
@@ -57,6 +74,8 @@ const updateTaskReducer = (state, action) => state.map(task => (task.id === acti
  */
 export default (state = mockTasks, action) => {
   switch (action.type) {
+    case ACCEPT:
+      return acceptTaskReducer(state, action);
     case CREATE:
       return createTaskReducer(state, action);
     case DELETE:
@@ -67,6 +86,18 @@ export default (state = mockTasks, action) => {
       return state;
   }
 };
+
+/**
+ * Action creator for dropping a Task in a TaskLane
+ * @params {string} destinationStatus - The status to be dropped onto
+ * @returns {Action}
+ */
+export const acceptTask = destinationStatus => ({
+  type: ACCEPT,
+  payload: {
+    status: destinationStatus
+  }
+});
 
 /**
  * Action creator for creating a new task.

--- a/yarn.lock
+++ b/yarn.lock
@@ -10311,6 +10311,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-trace-update@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-trace-update/-/use-trace-update-1.2.0.tgz#438a270e9cdde29e81e92f1e9b778b6095fc1011"
+  integrity sha512-DtLZ9dI2axENvDY4JZpchfYsEhN7zF+iz3sb9PzK90rmF6cMRSz5BUI4OXH5ZlQ+G8emLFF9wkvFQ3o0Ydk0RQ==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
# Summary

This PR implements the drag & drop functionalities for all the `<Task>`s within `<TaskLane>`s. Resolves #37.

![dnd](https://user-images.githubusercontent.com/8703536/58534446-35455f00-81a0-11e9-9251-453afd73fae3.gif)

Originally I wanted to use [React DnD](http://react-dnd.github.io/react-dnd/about), but that library is too complicated for this use case. Instead, I followed a guide here:

[React drag and drop, by *The Andela Way*](https://medium.com/the-andela-way/react-drag-and-drop-7411d14894b9) (hence the branch name, `feature/andela-drag`).

A couple of new concepts are explored in this branch, include using:

- The native HTML5 drag and drop API
- `React.memo` and `_.debounce` to optimize rerender and event handler callback performance 
- [use-trace-update](https://www.npmjs.com/package/use-trace-update) to track which prop change triggers a functional component rerender
- `bindActionCreators` to reduce the boilerplate in `mapDispatchToProps`.
